### PR TITLE
fix consuming messages when no message in topic

### DIFF
--- a/src/Haskakafka.hs
+++ b/src/Haskakafka.hs
@@ -145,6 +145,7 @@ consumeMessageBatch (KafkaTopic topicPtr _ _) partition timeout maxMessages =
   allocaArray maxMessages $ \outputPtr -> do
     numMessages <- rdKafkaConsumeBatch topicPtr (fromIntegral partition) timeout outputPtr (fromIntegral maxMessages)
     if numMessages < 0 then getErrno >>= return . Left . kafkaRespErr
+    else if numMessages == 0 then return . Right $ []
     else do
       ms <- forM [0..(numMessages - 1)] $ \mnum -> do 
               storablePtr <- peekElemOff outputPtr (fromIntegral mnum)


### PR DESCRIPTION
Fixes segmentation fault occuring when calling the `consumeMessageBatch` function when there's no more message to read from a topic. See #12.