### PR TITLE
Add seekToOffset

### DIFF
--- a/src/Haskakafka.hs
+++ b/src/Haskakafka.hs
@@ -82,13 +82,7 @@ addBrokers (Kafka kptr _) brokerStr = do
 -- 'consumeMessage' won't work without it. This function is non-blocking.
 startConsuming :: KafkaTopic -> Int -> KafkaOffset -> IO ()
 startConsuming (KafkaTopic topicPtr _ _) partition offset =
-    let trueOffset = case offset of
-                        KafkaOffsetBeginning -> (- 2)
-                        KafkaOffsetEnd -> (- 1)
-                        KafkaOffsetStored -> (- 1000)
-                        KafkaOffsetInvalid -> (- 1001)
-                        KafkaOffset i -> i
-    in throwOnError $ rdKafkaConsumeStart topicPtr partition trueOffset
+    throwOnError $ rdKafkaConsumeStart topicPtr partition $ offsetToInt64 offset
 
 -- | Stops consuming for a given topic. You probably do not need to call
 -- this directly (it is called automatically when 'withKafkaConsumer' terminates).

--- a/src/Haskakafka.hs
+++ b/src/Haskakafka.hs
@@ -8,6 +8,7 @@ module Haskakafka
 , produceKeyedMessage
 , produceMessageBatch
 , storeOffset
+, seekToOffset
 , getAllMetadata
 , getTopicMetadata
 
@@ -127,6 +128,18 @@ consumeMessageBatch (KafkaTopic topicPtr _ _) partition timeout maxMessages =
       case lefts ms of
         [] -> return $ Right $ rights ms
         l  -> return $ Left $ head l
+
+seekToOffset :: KafkaTopic
+    -> Int -- ^ partition number
+    -> KafkaOffset -- ^ destination
+    -> Int -- ^ timeout in milliseconds
+    -> IO (Maybe KafkaError)
+seekToOffset (KafkaTopic ptr _ _) p ofs timeout = do
+  err <- rdKafkaSeek ptr (fromIntegral p)
+      (fromIntegral $ offsetToInt64 ofs) timeout
+  case err of
+    RdKafkaRespErrNoError -> return Nothing
+    e -> return $ Just $ KafkaResponseError e
 
 -- | Store a partition's offset in librdkafka's offset store. This function only needs to be called
 -- if auto.commit.enable is false. See <https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md>

--- a/src/Haskakafka/Consumer/Internal/Convert.hs
+++ b/src/Haskakafka/Consumer/Internal/Convert.hs
@@ -3,12 +3,11 @@ module Haskakafka.Consumer.Internal.Convert
 where
 
 import           Control.Monad
-import           Data.Int
 import           Foreign
 import           Foreign.C.String
 import           Haskakafka.Consumer.Internal.Types
 import           Haskakafka.InternalRdKafka
-import           Haskakafka.InternalTypes
+import           Haskakafka.InternalShared
 
 -- | Converts offsets sync policy to integer (the way Kafka understands it):
 --
@@ -24,24 +23,6 @@ offsetSyncToInt sync =
         OffsetSyncImmediate -> 0
         OffsetSyncInterval ms -> ms
 {-# INLINE offsetSyncToInt #-}
-
-offsetToInt64 :: KafkaOffset -> Int64
-offsetToInt64 o = case o of
-    KafkaOffsetBeginning -> -2
-    KafkaOffsetEnd       -> -1
-    KafkaOffset off      -> off
-    KafkaOffsetStored    -> -1000
-    KafkaOffsetInvalid   -> -1001
-{-# INLINE offsetToInt64 #-}
-
-int64ToOffset :: Int64 -> KafkaOffset
-int64ToOffset o
-    | o == -2    = KafkaOffsetBeginning
-    | o == -1    = KafkaOffsetEnd
-    | o == -1000 = KafkaOffsetStored
-    | o >= 0     = KafkaOffset o
-    | otherwise  = KafkaOffsetInvalid
-{-# INLINE int64ToOffset #-}
 
 fromNativeTopicPartitionList :: RdKafkaTopicPartitionListT -> IO [KafkaTopicPartition]
 fromNativeTopicPartitionList pl =

--- a/src/Haskakafka/InternalRdKafka.chs
+++ b/src/Haskakafka/InternalRdKafka.chs
@@ -719,6 +719,10 @@ rdKafkaConsumeStart topicPtr partition offset = do
   {`RdKafkaTopicTPtr', cIntConv `CInt32T', `Int', castPtr `Ptr (Ptr RdKafkaMessageT)', cIntConv `CSize'}
   -> `CSize' cIntConv #}
 
+{#fun rd_kafka_seek as ^
+  {`RdKafkaTopicTPtr', cIntConv `CInt32T', cIntConv `CInt64T', `Int'}
+  -> `RdKafkaRespErrT' cIntToEnum #}
+
 rdKafkaConsumeStop :: RdKafkaTopicTPtr -> Int -> IO (Maybe String)
 rdKafkaConsumeStop topicPtr partition = do
     i <- rdKafkaConsumeStopInternal topicPtr (fromIntegral partition)

--- a/src/Haskakafka/InternalShared.hs
+++ b/src/Haskakafka/InternalShared.hs
@@ -73,6 +73,7 @@ offsetToInt64 o = case o of
     KafkaOffset off      -> off
     KafkaOffsetStored    -> -1000
     KafkaOffsetInvalid   -> -1001
+    KafkaOffsetTail i    -> -2000 - i
 {-# INLINE offsetToInt64 #-}
 
 int64ToOffset :: Int64 -> KafkaOffset
@@ -81,5 +82,6 @@ int64ToOffset o
     | o == -1    = KafkaOffsetEnd
     | o == -1000 = KafkaOffsetStored
     | o >= 0     = KafkaOffset o
+    | o <= -2000 = KafkaOffsetTail (-2000 - o)
     | otherwise  = KafkaOffsetInvalid
 {-# INLINE int64ToOffset #-}

--- a/src/Haskakafka/InternalShared.hs
+++ b/src/Haskakafka/InternalShared.hs
@@ -66,3 +66,20 @@ kafkaErrorToEither err = case err of
     _ -> Left err
 {-# INLINE kafkaErrorToEither #-}
 
+offsetToInt64 :: KafkaOffset -> Int64
+offsetToInt64 o = case o of
+    KafkaOffsetBeginning -> -2
+    KafkaOffsetEnd       -> -1
+    KafkaOffset off      -> off
+    KafkaOffsetStored    -> -1000
+    KafkaOffsetInvalid   -> -1001
+{-# INLINE offsetToInt64 #-}
+
+int64ToOffset :: Int64 -> KafkaOffset
+int64ToOffset o
+    | o == -2    = KafkaOffsetBeginning
+    | o == -1    = KafkaOffsetEnd
+    | o == -1000 = KafkaOffsetStored
+    | o >= 0     = KafkaOffset o
+    | otherwise  = KafkaOffsetInvalid
+{-# INLINE int64ToOffset #-}

--- a/src/Haskakafka/InternalTypes.hs
+++ b/src/Haskakafka/InternalTypes.hs
@@ -49,6 +49,7 @@ data KafkaOffset =
   -- <https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md librdkafka's documentation>
   -- for offset store configuration.
   | KafkaOffsetStored
+  | KafkaOffsetTail Int64
   | KafkaOffsetInvalid
   deriving (Eq, Show)
 


### PR DESCRIPTION
This patch adds a new function `seekToOffset`. This function binds `rd_kafka_seek`, which was introduced in librdkafka 0.9.