### PR TITLE
Use pkgconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,13 +139,7 @@ If the C++ bindings fail for you, just install the C bindings alone.
     cd librdkafka/src
     make && sudo make install
 
-On Debian and OS X, this will install the shared and static libraries to `/usr/local/lib`. Depending on your environment, you may need to configure environment variables to ensure that your libraries can be found by the compiler. For example:
-
-    export LD_LIBRARY_PATH=/usr/local/lib
-
-or
-
-    export C_INCLUDE_PATH=/usr/include/librdkafka
+On Debian and OS X, this will install the shared and static libraries to `/usr/local/lib`.
 
 ## Installing Kafka
 

--- a/haskakafka.cabal
+++ b/haskakafka.cabal
@@ -39,9 +39,7 @@ library
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall
-  include-dirs:        /usr/local/include/librdkafka
-  extra-lib-dirs:      /usr/local/lib
-  extra-libraries:     rdkafka
+  pkgconfig-depends:   rdkafka
 
 executable simple
   main-is:              Simple.hs

--- a/src/Haskakafka/InternalRdKafka.chs
+++ b/src/Haskakafka/InternalRdKafka.chs
@@ -15,7 +15,7 @@ import System.IO
 import System.Posix.IO
 import System.Posix.Types
 
-#include "rdkafka.h"
+#include "librdkafka/rdkafka.h"
 
 type CInt64T = {#type int64_t #}
 type CInt32T = {#type int32_t #}

--- a/src/Haskakafka/InternalRdKafkaEnum.chs
+++ b/src/Haskakafka/InternalRdKafkaEnum.chs
@@ -3,7 +3,7 @@
 
 module Haskakafka.InternalRdKafkaEnum where
 
-#include "rdkafka.h"
+#include "librdkafka/rdkafka.h"
 
 {#enum rd_kafka_type_t as ^ {underscoreToCase} deriving (Show, Eq) #}
 {#enum rd_kafka_conf_res_t as ^ {underscoreToCase} deriving (Show, Eq) #}


### PR DESCRIPTION
This patch modifies the .cabal file to use pkgconfig. This means users don't have to edit the .cabal file when their `librdkafka` instance is installed somewhere other than `/usr/local`.