### PR TITLE
Export constructors of RdKafkaRespErrT

### DIFF
--- a/src/Haskakafka.hs
+++ b/src/Haskakafka.hs
@@ -38,7 +38,7 @@ module Haskakafka
 
 , IT.KafkaLogLevel(..)
 , IT.KafkaError(..)
-, RDE.RdKafkaRespErrT
+, RDE.RdKafkaRespErrT(..)
 
 -- Pseudo-internal
 , addBrokers


### PR DESCRIPTION
Currently I often have to import one of the internal modules in order to get access to the constructors of `RdKafkaRespErrT`, because it's needed when I check whether a `consumeMessage` reached the end of stream or not.