### PR TITLE
Feature safe poll

### DIFF
--- a/src/Haskakafka.hs
+++ b/src/Haskakafka.hs
@@ -10,6 +10,8 @@ module Haskakafka
 , storeOffset
 , getAllMetadata
 , getTopicMetadata
+, withKafkaConf
+, withKafkaTopicConf
 
 -- Internal objects
 , IS.newKafka
@@ -290,6 +292,15 @@ withKafkaConsumer configOverrides topicConfigOverrides brokerString tName partit
       destroyKafka kafka)
     (\(k, t) -> cb k t)
 
+withKafkaConf :: (KafkaConf -> IO a) -> IO a
+withKafkaConf =
+  bracket newKafkaConf destroyKafkaConf
+
+withKafkaTopicConf :: (KafkaTopicConf -> IO a) -> IO a
+withKafkaTopicConf =
+  bracket newKafkaTopicConf destroyKafkaTopicConf
+
+
 {-# INLINE copyMsgFlags  #-}
 copyMsgFlags :: Int
 copyMsgFlags = rdKafkaMsgFlagCopy
@@ -318,7 +329,7 @@ fetchBrokerMetadata configOverrides brokerString timeout = do
       return kafka
     )
     destroyKafka
-    ((flip getAllMetadata) timeout)
+    (\k -> getAllMetadata k timeout)
 
 -- | Grabs all metadata from a given Kafka instance.
 getAllMetadata :: Kafka

--- a/src/Haskakafka.hs
+++ b/src/Haskakafka.hs
@@ -12,6 +12,9 @@ module Haskakafka
 , getTopicMetadata
 , withKafkaConf
 , withKafkaTopicConf
+, handleProduceErr
+, producePartitionInteger
+, pollEvents
 
 -- Internal objects
 , IS.newKafka
@@ -26,8 +29,8 @@ module Haskakafka
 , rdKafkaVersionStr
 
 -- Type re-exports
-, IT.Kafka
-, IT.KafkaTopic
+, IT.Kafka(..)
+, IT.KafkaTopic(..)
 
 , IT.KafkaOffset(..)
 , IT.KafkaMessage(..)

--- a/src/Haskakafka.hs
+++ b/src/Haskakafka.hs
@@ -21,6 +21,8 @@ module Haskakafka
 , IS.setLogLevel
 , IS.hPrintSupportedKafkaConf
 , IS.hPrintKafka
+, IS.destroyKafka
+, IS.destroyKafkaTopic
 , rdKafkaVersionStr
 
 -- Type re-exports

--- a/src/Haskakafka.hs
+++ b/src/Haskakafka.hs
@@ -11,8 +11,6 @@ module Haskakafka
 , seekToOffset
 , getAllMetadata
 , getTopicMetadata
-, withKafkaConf
-, withKafkaTopicConf
 , handleProduceErr
 , producePartitionInteger
 , pollEvents
@@ -306,15 +304,6 @@ withKafkaConsumer configOverrides topicConfigOverrides brokerString tName partit
       destroyKafkaTopic topic
       destroyKafka kafka)
     (\(k, t) -> cb k t)
-
-withKafkaConf :: (KafkaConf -> IO a) -> IO a
-withKafkaConf =
-  bracket newKafkaConf destroyKafkaConf
-
-withKafkaTopicConf :: (KafkaTopicConf -> IO a) -> IO a
-withKafkaTopicConf =
-  bracket newKafkaTopicConf destroyKafkaTopicConf
-
 
 {-# INLINE copyMsgFlags  #-}
 copyMsgFlags :: Int

--- a/src/Haskakafka.hs
+++ b/src/Haskakafka.hs
@@ -15,6 +15,7 @@ module Haskakafka
 , handleProduceErr
 , producePartitionInteger
 , pollEvents
+, pollEventsSafe
 
 -- Internal objects
 , IS.newKafka
@@ -421,6 +422,12 @@ getMetadata (Kafka kPtr _) mTopic timeout = alloca $ \mdDblPtr -> do
 
 pollEvents :: Kafka -> Int -> IO ()
 pollEvents (Kafka kPtr _) timeout = rdKafkaPoll kPtr timeout >> return ()
+
+pollEventsSafe :: Kafka -> Int -> IO ()
+pollEventsSafe (Kafka kPtr _) timeout = do
+  withForeignPtr kPtr $ \realPtr -> do
+    rdKafkaPollSafe realPtr timeout
+  return ()
 
 outboundQueueLength :: Kafka -> IO (Int)
 outboundQueueLength (Kafka kPtr _) = rdKafkaOutqLen kPtr

--- a/src/Haskakafka.hs
+++ b/src/Haskakafka.hs
@@ -231,6 +231,7 @@ produceMessageBatch (KafkaTopic topicPtr _ _) partition pms = do
                   , offset'RdKafkaMessageT = 0
                   , keyLen'RdKafkaMessageT = 0
                   , key'RdKafkaMessageT = nullPtr
+                  , private'RdKafkaMessageT = nullPtr
                   }
     produceMessageToMessage (KafkaProduceKeyedMessage kbs bs) =  do
         let (payloadFPtr, payloadOffset, payloadLength) = BSI.toForeignPtr bs
@@ -251,6 +252,7 @@ produceMessageBatch (KafkaTopic topicPtr _ _) partition pms = do
                     , offset'RdKafkaMessageT = 0
                     , keyLen'RdKafkaMessageT = keyLength
                     , key'RdKafkaMessageT = passedKey
+                    , private'RdKafkaMessageT = nullPtr
                     }
 
 -- | Connects to Kafka broker in producer mode for a given topic, taking a function
@@ -432,7 +434,7 @@ pollEvents (Kafka kPtr _) timeout = rdKafkaPoll kPtr timeout >> return ()
 
 pollEventsSafe :: Kafka -> Int -> IO ()
 pollEventsSafe (Kafka kPtr _) timeout = do
-  withForeignPtr kPtr $ \realPtr -> do
+  _ <- withForeignPtr kPtr $ \realPtr -> do
     rdKafkaPollSafe realPtr timeout
   return ()
 

--- a/src/Haskakafka/ConsumerExample.hs
+++ b/src/Haskakafka/ConsumerExample.hs
@@ -5,7 +5,7 @@ where
 import           Control.Arrow                  ((&&&))
 import           Haskakafka
 import           Haskakafka.Consumer
-import           Haskakafka.InternalRdKafkaEnum
+import           Haskakafka.InternalRdKafkaEnum ()
 
 iterator :: [Integer]
 iterator = [0 .. 20]

--- a/src/Haskakafka/InternalRdKafka.chs
+++ b/src/Haskakafka/InternalRdKafka.chs
@@ -686,8 +686,7 @@ foreign import ccall unsafe "rdkafka.h rd_kafka_destroy"
 newRdKafkaT :: RdKafkaTypeT -> RdKafkaConfTPtr -> IO (Either String RdKafkaTPtr)
 newRdKafkaT kafkaType confPtr =
     allocaBytes nErrorBytes $ \charPtr -> do
-        duper <- rdKafkaConfDup confPtr
-        ret <- rdKafkaNew kafkaType duper charPtr (fromIntegral nErrorBytes)
+        ret <- rdKafkaNew kafkaType confPtr charPtr (fromIntegral nErrorBytes)
         withForeignPtr ret $ \realPtr -> do
             if realPtr == nullPtr then peekCString charPtr >>= return . Left
             else return $ Right ret
@@ -782,8 +781,7 @@ foreign import ccall unsafe "rdkafka.h rd_kafka_topic_destroy"
 
 newRdKafkaTopicT :: RdKafkaTPtr -> String -> RdKafkaTopicConfTPtr -> IO (Either String RdKafkaTopicTPtr)
 newRdKafkaTopicT kafkaPtr topic topicConfPtr = do
-    duper <- rdKafkaTopicConfDup topicConfPtr
-    ret <- rdKafkaTopicNew kafkaPtr topic duper
+    ret <- rdKafkaTopicNew kafkaPtr topic topicConfPtr
     withForeignPtr ret $ \realPtr ->
         if realPtr == nullPtr then kafkaErrnoString >>= return . Left
         else do

--- a/src/Haskakafka/InternalRdKafka.chs
+++ b/src/Haskakafka/InternalRdKafka.chs
@@ -627,8 +627,8 @@ foreign import ccall unsafe "rdkafka.h rd_kafka_message_destroy"
 {#fun unsafe rd_kafka_conf_new as ^
     {} -> `RdKafkaConfTPtr' #}
 
-foreign import ccall unsafe "rdkafka.h &rd_kafka_conf_destroy"
-    rdKafkaConfDestroy :: FunPtr (Ptr RdKafkaConfT -> IO ())
+foreign import ccall unsafe "rdkafka.h rd_kafka_conf_destroy"
+    rdKafkaConfDestroy :: Ptr RdKafkaConfT -> IO ()
 
 {#fun unsafe rd_kafka_conf_dup as ^
     {`RdKafkaConfTPtr'} -> `RdKafkaConfTPtr' #}
@@ -640,7 +640,6 @@ foreign import ccall unsafe "rdkafka.h &rd_kafka_conf_destroy"
 newRdKafkaConfT :: IO RdKafkaConfTPtr
 newRdKafkaConfT = do
     ret <- rdKafkaConfNew
-    addForeignPtrFinalizer rdKafkaConfDestroy ret
     return ret
 
 {#fun unsafe rd_kafka_conf_dump as ^
@@ -658,8 +657,8 @@ newRdKafkaConfT = do
 {#fun unsafe rd_kafka_topic_conf_dup as ^
     {`RdKafkaTopicConfTPtr'} -> `RdKafkaTopicConfTPtr' #}
 
-foreign import ccall unsafe "rdkafka.h &rd_kafka_topic_conf_destroy"
-    rdKafkaTopicConfDestroy :: FunPtr (Ptr RdKafkaTopicConfT -> IO ())
+foreign import ccall unsafe "rdkafka.h rd_kafka_topic_conf_destroy"
+    rdKafkaTopicConfDestroy :: Ptr RdKafkaTopicConfT -> IO ()
 
 {#fun unsafe rd_kafka_topic_conf_set as ^
   {`RdKafkaTopicConfTPtr', `String', `String', id `CCharBufPointer', cIntConv `CSize'}
@@ -668,7 +667,6 @@ foreign import ccall unsafe "rdkafka.h &rd_kafka_topic_conf_destroy"
 newRdKafkaTopicConfT :: IO RdKafkaTopicConfTPtr
 newRdKafkaTopicConfT = do
     ret <- rdKafkaTopicConfNew
-    addForeignPtrFinalizer rdKafkaTopicConfDestroy ret
     return ret
 
 {#fun unsafe rd_kafka_topic_conf_dump as ^
@@ -689,8 +687,7 @@ newRdKafkaT kafkaType confPtr =
         ret <- rdKafkaNew kafkaType duper charPtr (fromIntegral nErrorBytes)
         withForeignPtr ret $ \realPtr -> do
             if realPtr == nullPtr then peekCString charPtr >>= return . Left
-            else do
-                return $ Right ret
+            else return $ Right ret
 
 {#fun unsafe rd_kafka_brokers_add as ^
     {`RdKafkaTPtr', `String'} -> `Int' #}

--- a/src/Haskakafka/InternalSetup.hs
+++ b/src/Haskakafka/InternalSetup.hs
@@ -68,18 +68,8 @@ type ConfigOverrides = [(String, String)]
 newKafkaTopicConf :: IO KafkaTopicConf
 newKafkaTopicConf = newRdKafkaTopicConfT >>= return . KafkaTopicConf
 
-destroyKafkaTopicConf :: KafkaTopicConf -> IO ()
-destroyKafkaTopicConf (KafkaTopicConf topicConf) =
-  withForeignPtr topicConf $ \realPtr ->
-    rdKafkaTopicConfDestroy realPtr
-
 newKafkaConf :: IO KafkaConf
 newKafkaConf = newRdKafkaConfT >>= return . KafkaConf
-
-destroyKafkaConf :: KafkaConf -> IO ()
-destroyKafkaConf (KafkaConf conf) =
-  withForeignPtr conf $ \realPtr ->
-    rdKafkaConfDestroy realPtr
 
 kafkaConf :: ConfigOverrides -> IO (KafkaConf)
 kafkaConf overrides = do

--- a/src/Haskakafka/InternalSetup.hs
+++ b/src/Haskakafka/InternalSetup.hs
@@ -19,22 +19,11 @@ import qualified Data.Map.Strict                as Map
 newKafka :: RdKafkaTypeT -> ConfigOverrides -> IO Kafka
 newKafka kafkaType overrides = (kafkaConf overrides) >>= newKafkaPtr kafkaType
 
--- | Destroy kafka object
-destroyKafka :: Kafka -> IO ()
-destroyKafka kafka = do
-  withForeignPtr (kafkaPtr kafka) $ \realPtr -> do
-    rdKafkaDestroy realPtr
-
 -- | Create a kafka topic object with the given configuration. Most of the
 -- time you will not need to use this function directly
 -- (see 'withKafkaProducer' and 'withKafkaConsumer')
 newKafkaTopic :: Kafka -> String -> ConfigOverrides -> IO KafkaTopic
 newKafkaTopic k tName overrides = (kafkaTopicConf overrides) >>= newKafkaTopicPtr k tName
-
-destroyKafkaTopic :: KafkaTopic -> IO ()
-destroyKafkaTopic (KafkaTopic topic _ _) =
-  withForeignPtr topic $ \realPtr ->
-    rdKafkaTopicDestroy realPtr
 
 newKafkaPtr :: RdKafkaTypeT -> KafkaConf -> IO Kafka
 newKafkaPtr kafkaType c@(KafkaConf confPtr) = do

--- a/src/Haskakafka/InternalSetup.hs
+++ b/src/Haskakafka/InternalSetup.hs
@@ -68,8 +68,18 @@ type ConfigOverrides = [(String, String)]
 newKafkaTopicConf :: IO KafkaTopicConf
 newKafkaTopicConf = newRdKafkaTopicConfT >>= return . KafkaTopicConf
 
+destroyKafkaTopicConf :: KafkaTopicConf -> IO ()
+destroyKafkaTopicConf (KafkaTopicConf topicConf) =
+  withForeignPtr topicConf $ \realPtr ->
+    rdKafkaTopicConfDestroy realPtr
+
 newKafkaConf :: IO KafkaConf
 newKafkaConf = newRdKafkaConfT >>= return . KafkaConf
+
+destroyKafkaConf :: KafkaConf -> IO ()
+destroyKafkaConf (KafkaConf conf) =
+  withForeignPtr conf $ \realPtr ->
+    rdKafkaConfDestroy realPtr
 
 kafkaConf :: ConfigOverrides -> IO (KafkaConf)
 kafkaConf overrides = do

--- a/tests/TestMain.hs
+++ b/tests/TestMain.hs
@@ -52,47 +52,48 @@ testmain = hspec $ do
 
   describe "Kafka Configuration" $ do
     it "should allow dumping" $ do
-      kConf <- newKafkaConf
-      kvs <- dumpKafkaConf kConf
-      (Map.size kvs) `shouldSatisfy` (>0)
+      withKafkaConf $ \kConf -> do
+        kvs <- dumpKafkaConf kConf
+        (Map.size kvs) `shouldSatisfy` (>0)
 
     it "should change when set is called" $ do
-      kConf <- newKafkaConf
-      setKafkaConfValue kConf "socket.timeout.ms" "50000"
-      kvs <- dumpKafkaConf kConf
-      (kvs Map.! "socket.timeout.ms") `shouldBe` "50000"
+      withKafkaConf $ \kConf -> do
+        setKafkaConfValue kConf "socket.timeout.ms" "50000"
+        kvs <- dumpKafkaConf kConf
+        (kvs Map.! "socket.timeout.ms") `shouldBe` "50000"
 
     it "should throw an exception on unknown property" $ do
-      kConf <- newKafkaConf
-      (setKafkaConfValue kConf "blippity.blop.cosby" "120") `shouldThrow`
-        (\(KafkaUnknownConfigurationKey str) -> (length str) > 0)
+      withKafkaConf $ \kConf -> do
+        (setKafkaConfValue kConf "blippity.blop.cosby" "120") `shouldThrow`
+          (\(KafkaUnknownConfigurationKey str) -> (length str) > 0)
 
     it "should throw an exception on an invalid value" $ do
-      kConf <- newKafkaConf
-      (setKafkaConfValue kConf "socket.timeout.ms" "monorail") `shouldThrow`
-        (\(KafkaInvalidConfigurationValue str) -> (length str) > 0)
+      withKafkaConf $ \kConf -> do
+        (setKafkaConfValue kConf "socket.timeout.ms" "monorail") `shouldThrow`
+          (\(KafkaInvalidConfigurationValue str) -> (length str) > 0)
 
   describe "Kafka topic configuration" $ do
     it "should allow dumping" $ do
-      kConf <- newKafkaTopicConf
-      kvs <- dumpKafkaTopicConf kConf
-      (Map.size kvs) `shouldSatisfy` (>0)
+      withKafkaTopicConf $ \kTopicConf -> do
+        kvs <- dumpKafkaTopicConf kTopicConf
+        (Map.size kvs) `shouldSatisfy` (>0)
 
     it "should change when set is called" $ do
-      kConf <- newKafkaTopicConf
-      setKafkaTopicConfValue kConf "request.timeout.ms" "20000"
-      kvs <- dumpKafkaTopicConf kConf
-      (kvs Map.! "request.timeout.ms") `shouldBe` "20000"
+      withKafkaTopicConf $ \kTopicConf -> do
+        setKafkaTopicConfValue kTopicConf "request.timeout.ms" "20000"
+        kvs <- dumpKafkaTopicConf kTopicConf
+        (kvs Map.! "request.timeout.ms") `shouldBe` "20000"
 
     it "should throw an exception on unknown property" $ do
-      kConf <- newKafkaTopicConf
-      (setKafkaTopicConfValue kConf "blippity.blop.cosby" "120") `shouldThrow`
-        (\(KafkaUnknownConfigurationKey str) -> (length str) > 0)
+      withKafkaTopicConf $ \kTopicConf -> do
+        (setKafkaTopicConfValue kTopicConf "blippity.blop.cosby" "120") `shouldThrow`
+          (\(KafkaUnknownConfigurationKey str) -> (length str) > 0)
 
     it "should throw an exception on an invalid value" $ do
-      kConf <- newKafkaTopicConf
-      (setKafkaTopicConfValue kConf "request.timeout.ms" "mono...doh!") `shouldThrow`
-        (\(KafkaInvalidConfigurationValue str) -> (length str) > 0)
+      withKafkaTopicConf $ \kTopicConf -> do
+        (setKafkaTopicConfValue kTopicConf "request.timeout.ms" "mono...doh!")
+          `shouldThrow`
+          (\(KafkaInvalidConfigurationValue str) -> (length str) > 0)
 
   describe "Logging" $ do
     it "should allow setting of log level" $ getAddressTopic $ \a t -> do

--- a/tests/TestMain.hs
+++ b/tests/TestMain.hs
@@ -52,48 +52,48 @@ testmain = hspec $ do
 
   describe "Kafka Configuration" $ do
     it "should allow dumping" $ do
-      withKafkaConf $ \kConf -> do
-        kvs <- dumpKafkaConf kConf
-        (Map.size kvs) `shouldSatisfy` (>0)
+      kConf <- newKafkaConf
+      kvs <- dumpKafkaConf kConf
+      (Map.size kvs) `shouldSatisfy` (>0)
 
     it "should change when set is called" $ do
-      withKafkaConf $ \kConf -> do
-        setKafkaConfValue kConf "socket.timeout.ms" "50000"
-        kvs <- dumpKafkaConf kConf
-        (kvs Map.! "socket.timeout.ms") `shouldBe` "50000"
+      kConf <- newKafkaConf
+      setKafkaConfValue kConf "socket.timeout.ms" "50000"
+      kvs <- dumpKafkaConf kConf
+      (kvs Map.! "socket.timeout.ms") `shouldBe` "50000"
 
     it "should throw an exception on unknown property" $ do
-      withKafkaConf $ \kConf -> do
-        (setKafkaConfValue kConf "blippity.blop.cosby" "120") `shouldThrow`
-          (\(KafkaUnknownConfigurationKey str) -> (length str) > 0)
+      kConf <- newKafkaConf
+      (setKafkaConfValue kConf "blippity.blop.cosby" "120") `shouldThrow`
+        (\(KafkaUnknownConfigurationKey str) -> (length str) > 0)
 
     it "should throw an exception on an invalid value" $ do
-      withKafkaConf $ \kConf -> do
-        (setKafkaConfValue kConf "socket.timeout.ms" "monorail") `shouldThrow`
-          (\(KafkaInvalidConfigurationValue str) -> (length str) > 0)
+      kConf <- newKafkaConf
+      (setKafkaConfValue kConf "socket.timeout.ms" "monorail") `shouldThrow`
+        (\(KafkaInvalidConfigurationValue str) -> (length str) > 0)
 
   describe "Kafka topic configuration" $ do
     it "should allow dumping" $ do
-      withKafkaTopicConf $ \kTopicConf -> do
-        kvs <- dumpKafkaTopicConf kTopicConf
-        (Map.size kvs) `shouldSatisfy` (>0)
+      kTopicConf <- newKafkaTopicConf
+      kvs <- dumpKafkaTopicConf kTopicConf
+      (Map.size kvs) `shouldSatisfy` (>0)
 
     it "should change when set is called" $ do
-      withKafkaTopicConf $ \kTopicConf -> do
-        setKafkaTopicConfValue kTopicConf "request.timeout.ms" "20000"
-        kvs <- dumpKafkaTopicConf kTopicConf
-        (kvs Map.! "request.timeout.ms") `shouldBe` "20000"
+      kTopicConf <- newKafkaTopicConf
+      setKafkaTopicConfValue kTopicConf "request.timeout.ms" "20000"
+      kvs <- dumpKafkaTopicConf kTopicConf
+      (kvs Map.! "request.timeout.ms") `shouldBe` "20000"
 
     it "should throw an exception on unknown property" $ do
-      withKafkaTopicConf $ \kTopicConf -> do
-        (setKafkaTopicConfValue kTopicConf "blippity.blop.cosby" "120") `shouldThrow`
-          (\(KafkaUnknownConfigurationKey str) -> (length str) > 0)
+      kTopicConf <- newKafkaTopicConf
+      (setKafkaTopicConfValue kTopicConf "blippity.blop.cosby" "120") `shouldThrow`
+        (\(KafkaUnknownConfigurationKey str) -> (length str) > 0)
 
     it "should throw an exception on an invalid value" $ do
-      withKafkaTopicConf $ \kTopicConf -> do
-        (setKafkaTopicConfValue kTopicConf "request.timeout.ms" "mono...doh!")
-          `shouldThrow`
-          (\(KafkaInvalidConfigurationValue str) -> (length str) > 0)
+      kTopicConf <- newKafkaTopicConf
+      (setKafkaTopicConfValue kTopicConf "request.timeout.ms" "mono...doh!")
+        `shouldThrow`
+        (\(KafkaInvalidConfigurationValue str) -> (length str) > 0)
 
   describe "Logging" $ do
     it "should allow setting of log level" $ getAddressTopic $ \a t -> do


### PR DESCRIPTION
Hi,

This pull request introduces the functions

- `pollEventsSafe`
- `withKafkaConf`
- `withKafkaTopicConf` 

`pollEventsSafe` is because I was running into threading issues when polling for a delivery callback. However, I wasn't sure that it made sense to change the current `pollEvents` function to be safe, if it is not needed for most cases. In addition, I added the `_private` field to `rdKafkaMessageT` to retrieve the `opaque` pointer from the delivery callback. This lets you implement things like synchronous message producing if you want it. In addition, `pollEvents`, `pollEventsSafe`, `handleProduceErr`, and `producePartitionInteger` are exported from `Haskakafka.hs`. I had thought of implementing synchronous producing in Haskakafka itself, but it requires setting a delivery callback, and it's not something that's officially implemented in librdkafka yet.

`withKafkaConf` and `withKafkaTopicConf` are a followup to the last pull request. The finalizers have been removed for `rdKafkaConf` and `rdKafkaTopicConf`, and replaced with bracket methods for working with the confs by themselves. This partly fixes an issue with cleanly shutting down the tests when there is no connection, although the issue still persists due to a `rd_kafka_metadata` bug in `librdkafka`.

Cheers,

Justin