### PR TITLE
Resolve #27. Enable compilation against 0.9.1

### DIFF
--- a/haskakafka.cabal
+++ b/haskakafka.cabal
@@ -26,8 +26,8 @@ library
                      , unix
   exposed-modules:
     Haskakafka
-    Haskakafka.InternalRdKafka
     Haskakafka.InternalRdKafkaEnum
+    Haskakafka.InternalRdKafka
     Haskakafka.InternalSetup
     Haskakafka.InternalTypes
     Haskakafka.ConsumerExample

--- a/src/Haskakafka/InternalRdKafka.chs
+++ b/src/Haskakafka/InternalRdKafka.chs
@@ -17,6 +17,8 @@ import System.Posix.Types
 
 #include "librdkafka/rdkafka.h"
 
+{#import Haskakafka.InternalRdKafkaEnum#}
+
 type CInt64T = {#type int64_t #}
 type CInt32T = {#type int32_t #}
 
@@ -517,8 +519,12 @@ newRdKafkaQueue k = do
     {`RdKafkaTPtr', `RdKafkaMessageTPtr', `Int'}
     -> `RdKafkaRespErrT' cIntToEnum #}
 
-{#fun unsafe rd_kafka_position as ^
+{#fun unsafe rd_kafka_committed as ^
     {`RdKafkaTPtr', `RdKafkaTopicPartitionListTPtr', `Int'}
+    -> `RdKafkaRespErrT' cIntToEnum #}
+
+{#fun unsafe rd_kafka_position as ^
+    {`RdKafkaTPtr', `RdKafkaTopicPartitionListTPtr'}
     -> `RdKafkaRespErrT' cIntToEnum #}
 -------------------------------------------------------------------------------------------------
 ---- Groups
@@ -625,6 +631,9 @@ foreign import ccall unsafe "rdkafka.h &rd_kafka_list_groups"
 -- rd_kafka_message
 foreign import ccall unsafe "rdkafka.h rd_kafka_message_destroy"
     rdKafkaMessageDestroy :: Ptr RdKafkaMessageT -> IO ()
+
+{#fun unsafe rd_kafka_message_timestamp as ^
+    {`RdKafkaMessageTPtr', `RdKafkaTimestampTypeTPtr'} -> `CInt64T' cIntConv #}
 
 -- rd_kafka_conf
 {#fun unsafe rd_kafka_conf_new as ^

--- a/src/Haskakafka/InternalRdKafkaEnum.chs
+++ b/src/Haskakafka/InternalRdKafkaEnum.chs
@@ -8,3 +8,6 @@ module Haskakafka.InternalRdKafkaEnum where
 {#enum rd_kafka_type_t as ^ {underscoreToCase} deriving (Show, Eq) #}
 {#enum rd_kafka_conf_res_t as ^ {underscoreToCase} deriving (Show, Eq) #}
 {#enum rd_kafka_resp_err_t as ^ {underscoreToCase} deriving (Show, Eq) #}
+{#enum rd_kafka_timestamp_type_t as ^ {underscoreToCase} deriving (Show, Eq) #}
+
+{#pointer *rd_kafka_timestamp_type_t as RdKafkaTimestampTypeTPtr foreign -> RdKafkaTimestampTypeT #}


### PR DESCRIPTION
Updated bindings to include all additions since 0.9.0.99:
-   `rd_kafka_position` renamed to `rd_kafka_committed`
-   Added bindings to new version of `rd_kafka_position`
-   Added bindings to `rd_kafka_timestamp_type_t` and
  `rd_kafka_message_timestamp`
-   Reordered `InternalRdKafkaEnum.chs` in `haskakafka.cabal` to enable
  `{#import ... }` of `rd_timestamp_type_t *` in `InternalRdKafka.chs`
