### PR TITLE
Add `queryWatermarkOffsets`

### DIFF
--- a/src/Haskakafka/InternalRdKafka.chs
+++ b/src/Haskakafka/InternalRdKafka.chs
@@ -803,6 +803,15 @@ newRdKafkaTopicT kafkaPtr topic topicConfPtr = do
             addForeignPtrFinalizer rdKafkaTopicDestroy ret
             return $ Right ret
 
+{#fun unsafe rd_kafka_query_watermark_offsets as rdKafkaQueryWatermarkOffsetsInternal
+   { `RdKafkaTPtr'
+   , id `CCharBufPointer'
+   , cIntConv `CInt32T'
+   , id `Ptr CLong'
+   , id `Ptr CLong'
+   ,`Int'}
+   -> `RdKafkaRespErrT' cIntToEnum #}
+
 -- Marshall / Unmarshall
 enumToCInt :: Enum a => a -> CInt
 enumToCInt = fromIntegral . fromEnum


### PR DESCRIPTION
```
/**
 * @brief Query broker for low (oldest/beginning) and high (newest/end) offsets
 *        for partition.
 *
 * Offsets are returned in \p *low and \p *high respectively.
 *
 * @returns RD_KAFKA_RESP_ERR_NO_ERROR on success or an error code on failure.
```
https://github.com/edenhill/librdkafka/blob/master/src/rdkafka.h#L1707